### PR TITLE
fix disable migrations guide

### DIFF
--- a/source/docs/index.md
+++ b/source/docs/index.md
@@ -119,7 +119,7 @@ use Filament\Filament;
 Filament::ignoreMigrations();
 ```
 
-from the `boot()` method of your `AppServiceProvider`.
+from the `register()` method of your `AppServiceProvider`.
 
 ## Stubs {#stubs}
 


### PR DESCRIPTION
`Filament::ignoreMigrations()` has to be called from `register()` as the `\App\Providers\AppServiceProvider::boot()` runs after `\Filament\FilamentServiceProvider::bootLoaders()` which loads the package migrations.
As all register methods are called before the boot this is the easiest fix.