### PR TITLE
Update Disabling Default Widget directions

### DIFF
--- a/source/docs/dashboard.md
+++ b/source/docs/dashboard.md
@@ -27,11 +27,10 @@ By default two widgets are displayed on the dashboard. These widgets can be disa
 
 ```php
   'widgets' => [
-      'namespace' => 'App\\Filament\\Widgets',
-      'path' => app_path('Filament/Widgets'),
+      // ...
       'default' => [
-          'account' => true, // Change to false to disable account widget
-          'info' => true, // Change to false to disable info widget
+          'account' => false, // Disables the account widget.
+          'info' => false, // Disables the info widget.
       ],
   ],
 ```

--- a/source/docs/dashboard.md
+++ b/source/docs/dashboard.md
@@ -23,7 +23,7 @@ Widgets are pure [Laravel Livewire](https://laravel-livewire.com) components, so
 
 ## Disabling the Default Widgets {#disabling-default-widgets}
 
-By default two widgets are displayed on the dashboard. These widgets can be disabled by updating the `widgets` section of the [configuration](/docs#configuration) file. Updating the entries to `false` will remove the corresponding widget from the Dashboard.
+By default, two widgets are displayed on the dashboard. These widgets can be disabled by updating the `widgets` section of the [configuration](/docs#configuration) file. Updating each entries to `false` will remove the corresponding default widget from the dashboard.
 
 ```php
   'widgets' => [

--- a/source/docs/dashboard.md
+++ b/source/docs/dashboard.md
@@ -23,4 +23,15 @@ Widgets are pure [Laravel Livewire](https://laravel-livewire.com) components, so
 
 ## Disabling the Default Widgets {#disabling-default-widgets}
 
-You may disable the default dashboard widgets by [configuring](/docs#configuration) Filament with `widgets.default.account` and `widgets.default.info` set to false.
+By default two widgets are displayed on the dashboard. These widgets can be disabled by updating the `widgets` section of the [configuration](/docs#configuration) file. Updating the entries to `false` will remove the corresponding widget from the Dashboard.
+
+```php
+  'widgets' => [
+      'namespace' => 'App\\Filament\\Widgets',
+      'path' => app_path('Filament/Widgets'),
+      'default' => [
+          'account' => true, // Change to false to disable account widget
+          'info' => true, // Change to false to disable info widget
+      ],
+  ],
+```


### PR DESCRIPTION
While checking out filament I started looking into the dashboard and was confused about the previous description. I've updated the description to hopefully have it make more sense.

The use of the "dot notation" for a config setting path didn't occur to me until I started looking for a "widget" section. After finding the setting the "dot notation" did make more sense since that is how you access config settings using the `Config` class but I figured a better explanation might be useful.

P.S. - Great work... excited to see filament evolve!